### PR TITLE
Chore: Tidy Up Trip Service Kata

### DIFF
--- a/trip_service/GemFile
+++ b/trip_service/GemFile
@@ -1,3 +1,5 @@
-source 'http://rubygems.org/' do
-    gem 'mocha'
+source "https://rubygems.org"
+
+group :test do
+  gem "rspec"
 end

--- a/trip_service/Gemfile.lock
+++ b/trip_service/Gemfile.lock
@@ -1,0 +1,26 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.5.0)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+
+PLATFORMS
+  arm64-darwin-20
+
+DEPENDENCIES
+  rspec
+
+BUNDLED WITH
+   2.3.12

--- a/trip_service/spec/trip_service_spec.rb
+++ b/trip_service/spec/trip_service_spec.rb
@@ -1,0 +1,5 @@
+require_relative '../trip/trip_service'
+
+RSpec.describe TripService do
+
+end

--- a/trip_service/tests/trip_service_tests.rb
+++ b/trip_service/tests/trip_service_tests.rb
@@ -1,5 +1,0 @@
-require 'test/unit'
-
-class TripServiceTests < Test::Unit::TestCase
-
-end

--- a/trip_service/trip/trip_dao.rb
+++ b/trip_service/trip/trip_dao.rb
@@ -1,7 +1,7 @@
 require_relative '../еxceptions/dependend_class_call_during_unit_test_exception'
 
 class TripDAO
-    def self.find_trips_by_user(user)
-        raise DependendClassCallDuringUnitTestException.new('TripDAO should not be invoked on an unit test.')
-    end
+  def self.find_trips_by_user(user)
+    raise DependendClassCallDuringUnitTestException.new('TripDAO should not be invoked on an unit test.')
+  end
 end

--- a/trip_service/trip/trip_service.rb
+++ b/trip_service/trip/trip_service.rb
@@ -6,28 +6,28 @@ require_relative '../еxceptions/dependend_class_call_during_unit_test_exception
 
 class TripService
 
-    def get_trip_by_user(user)
-        trip_list = []
-        logged_user = UserSession.get_instance.get_logged_user
-        is_friend = false
+  def get_trip_by_user(user)
+    trip_list = []
+    logged_user = UserSession.get_instance.get_logged_user
+    is_friend = false
 
-        if(!logged_user.nil?)
-            user.get_friends.each do |f|
-                if(f.equal? logged_user)
-                    is_friend = true
-                    break
-                end
-            end
-
-            if(is_friend)
-                trip_list = TripDAO.find_trips_by_user(user)
-            end
-
-            return trip_list
-        else
-            raise UserNotLoggedInException.new
+    if(!logged_user.nil?)
+      user.get_friends.each do |f|
+        if(f.equal? logged_user)
+          is_friend = true
+          break
         end
+      end
 
+      if(is_friend)
+        trip_list = TripDAO.find_trips_by_user(user)
+      end
+
+      return trip_list
+    else
+      raise UserNotLoggedInException.new
     end
+
+  end
 
 end

--- a/trip_service/user/user.rb
+++ b/trip_service/user/user.rb
@@ -1,22 +1,22 @@
 class User
-    def initialize
-        @trips = []
-        @friends = []
-    end
+  def initialize
+    @trips = []
+    @friends = []
+  end
 
-    def get_friends
-        @friends
-    end
+  def get_friends
+    @friends
+  end
 
-    def add_friend(user)
-        @friends << user
-    end
+  def add_friend(user)
+    @friends << user
+  end
 
-    def add_trip(trip)
-        @trips << trip
-    end
+  def add_trip(trip)
+    @trips << trip
+  end
 
-    def trips
-        @trips
-    end
+  def trips
+    @trips
+  end
 end

--- a/trip_service/user/user_session.rb
+++ b/trip_service/user/user_session.rb
@@ -1,19 +1,19 @@
 require_relative '../еxceptions/dependend_class_call_during_unit_test_exception'
 
 class UserSession
-    @@user_session = UserSession.new
+  @@user_session = UserSession.new
 
-    def self.get_instance
-        @@user_session
-    end
+  def self.get_instance
+    @@user_session
+  end
 
-    def is_user_logged_in(user)
-        raise DependendClassCallDuringUnitTestException.new('UserSession.is_user_logged_in should not be called in an unit test')
-    end
+  def is_user_logged_in(user)
+    raise DependendClassCallDuringUnitTestException.new('UserSession.is_user_logged_in should not be called in an unit test')
+  end
 
-    def get_logged_user
-        raise DependendClassCallDuringUnitTestException.new('UserSession.get_logged_user should not be called in an unit test')
-    end
+  def get_logged_user
+    raise DependendClassCallDuringUnitTestException.new('UserSession.get_logged_user should not be called in an unit test')
+  end
 
-    private_class_method :new
+  private_class_method :new
 end

--- a/trip_service/еxceptions/dependend_class_call_during_unit_test_exception.rb
+++ b/trip_service/еxceptions/dependend_class_call_during_unit_test_exception.rb
@@ -1,5 +1,5 @@
 class DependendClassCallDuringUnitTestException < StandardError
-    def initialize(msg)
-        super(msg)
-    end
+	def initialize(msg)
+		super(msg)
+	end
 end

--- a/trip_service/еxceptions/user_not_logged_in_exception.rb
+++ b/trip_service/еxceptions/user_not_logged_in_exception.rb
@@ -1,3 +1,1 @@
-class UserNotLoggedInException < StandardError
-
-end
+class UserNotLoggedInException < StandardError; end


### PR DESCRIPTION
Because:
* To make it easier to get started on in the future.

This commit:
* Fix indentation to follow Ruby Style Guide (2 spaces)
* Switch to RSpec.